### PR TITLE
Change the defaultVersion to 19.0 for the Keycloak service

### DIFF
--- a/services/templates/keycloak.yaml
+++ b/services/templates/keycloak.yaml
@@ -23,7 +23,7 @@ services:
     environment:
       - KC_HEALTH_ENABLED=true
       - KC_PROXY=edge
-      - KC_DB=postgres
+      - KC_HOSTNAME_STRICT_HTTPS=false
       - KC_HOSTNAME=$$config_keycloak_domain
       - KEYCLOAK_ADMIN=$$config_admin_user
       - KEYCLOAK_ADMIN_PASSWORD=$$secret_keycloak_admin_password

--- a/services/templates/keycloak.yaml
+++ b/services/templates/keycloak.yaml
@@ -1,5 +1,5 @@
 templateVersion: 1.0.0
-defaultVersion: '20.0'
+defaultVersion: '19.0'
 documentation: https://www.keycloak.org/documentation
 type: keycloak
 name: Keycloak
@@ -23,7 +23,6 @@ services:
     environment:
       - KC_HEALTH_ENABLED=true
       - KC_PROXY=edge
-      - KC_HOSTNAME_STRICT_HTTPS=false
       - KC_HOSTNAME=$$config_keycloak_domain
       - KEYCLOAK_ADMIN=$$config_admin_user
       - KEYCLOAK_ADMIN_PASSWORD=$$secret_keycloak_admin_password
@@ -34,7 +33,6 @@ services:
       - '8080'
   $$id-postgresql:
     name: PostgreSQL
-    depends_on: []
     image: postgres:14-alpine
     volumes:
       - $$id-postgresql-data:/var/lib/postgresql/data


### PR DESCRIPTION
The 20.0 images seem to be having trouble start up in my oracle aarch64 instance of coolify. The 19.0 images are working fine though so it might be something that was changed in v20 that I haven't figured out yet.