### PR TITLE
Add SerpBear as a service

### DIFF
--- a/services/templates/serpbear.yaml
+++ b/services/templates/serpbear.yaml
@@ -1,0 +1,60 @@
+templateVersion: 1.0.0
+defaultVersion: latest # the only version available from docekr hub.
+documentation: https://docs.serpbear.com
+type: serpbear
+name: SerpBear
+description: Search Engine Position Rank Tracking App
+labels:
+  - serp
+  - seo
+services:
+  $$id:
+    name: SerpBear
+    documentation: https://github.com/towfiqi/serpbear
+    image: towfiqi/serpbear:$$core_version
+    volumes:
+      - $$id-app-data:/app/data
+    environment:
+      - USER=$$config_user
+      - PASSWORD=$$secret_password
+      - SECRET=$$secret_secret
+      - APIKEY=$$secret_api_key
+      - SESSION_DURATION=$$config_session_duration
+      - NEXT_PUBLIC_APP_URL=$$config_base_url
+    ports:
+      - "808"
+variables:
+  - id: $$config_user
+    name: USER
+    label: User
+    defaultValue: $$generate_username
+    description: "Username to login with"
+    showOnConfiguration: true
+  - id: $$config_user
+    name: PASSWORD
+    label: Password
+    defaultValue: $$generate_password
+    description: "Password to login with"
+    showOnConfiguration: true
+  - id: $$secret_secret
+    name: SECRET
+    label: Secret
+    defaultValue: $$generate_password
+    description: "Secret key to encrypt third-party api-keys and passwords"
+  - id: $$secret_api_key
+    name: APIKEY
+    label: API Key
+    defaultValue: $$generate_password
+    description: "The API you want to use to access the SerpBear API"
+    showOnConfiguration: true
+  - id: $$config_session_duration
+    name: SESSION_DURATION
+    label: Session Duration
+    defaultValue: "24"
+    description: "How long a session lasts in hours"
+    showOnConfiguration: true
+  - id: $$config_base_url
+    name: NEXT_PUBLIC_APP_URL
+    label: Base URL
+    defaultValue: $$generate_fqdn
+    description: ""


### PR DESCRIPTION
Not tested locally, as I don't want to end up with the same problem as in https://github.com/coollabsio/coolify-community-templates/pull/31.

---

Adds [SerpBear](https://docs.serpbear.com) as a service to Coolify :sunglasses:  

I owe them a **huge** shout-out, it's fantastic check SERP-data of my sites, but not ~$30/m without getting any extraordinary functionality also :cupid: This is the reason I would rather be in complete control of my data.

The below table is shamelessly stolen directly from the SerpBear [README](https://github.com/towfiqi/serpbear#compare-serpbear-with-other-serp-tracking-services) as I think it's useful information for users to know.

|Service  | Cost | SERP Lookup | API |
|--|--|--|--|
| SerpBear | Free* | Unlimited* | Yes |
| ranktracker.com | $18/mo| 3,000/mo| No |
| SerpWatch.io | $29/mo | 7500/mo | Yes |
| Serpwatcher.com | $49/mo| 3000/mo | No |
| whatsmyserp.com | $49/mo| 30,000/mo| No |
| serply.io | $49/mo | 5000/mo | Yes |
| serpapi.com | From $50/mo** | From 5,000/mo** | Yes |

You do need to get an API-key from an external scraping-service. I've chosen [ScrapingRobot](https://billing.scrapingrobot.com/aff.php?aff=2) - this is even though [ScrapingAnt](https://scrapingant.com) were supposedly more generous, but it was not possible for me to use them - I think they've blocked Google scraping in their free-tier :shrug: 

![Scraping Methods](https://user-images.githubusercontent.com/1170567/219141219-8c8a3200-5bb6-4766-9053-1222c8e1835b.png)
