### PR TITLE
Update Pocketbase version & add hooks directory

### DIFF
--- a/services/templates/pocketbase.yaml
+++ b/services/templates/pocketbase.yaml
@@ -1,5 +1,5 @@
 templateVersion: 1.0.0
-defaultVersion: 0.16.10
+defaultVersion: 0.17.6
 documentation: https://pocketbase.io/docs/
 type: pocketbase
 name: Pocketbase
@@ -9,5 +9,6 @@ services:
     image: ghcr.io/coollabsio/pocketbase:$$core_version
     volumes:
       - $$id-data:/app/pb_data
+      - $$id-hooks:/app/pb_hooks
     ports:
       - '8080'


### PR DESCRIPTION
I couldn't found a way to use pocketbase hooks on coolify. This would help to store files in the pb_hooks directory so pocketbase can pick them up.